### PR TITLE
Add support for games without `default` (E.g, Mineclonia & Voxelibre)

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,2 +1,0 @@
-mobkit
-default

--- a/init.lua
+++ b/init.lua
@@ -1,14 +1,5 @@
 --local abr = minetest.get_mapgen_setting('active_block_range')
 
-local player_compat = nil
-local player_compat_animate = true
-if core.get_modpath("default") then
-	player_compat = player_api
-elseif core.get_modpath("mcl_core") then
-	player_compat = mcl_player
-	player_compat_animate = false
-end
-
 local pi = math.pi
 local random = math.random
 local min = math.min
@@ -300,17 +291,17 @@ on_rightclick=function(self, clicker)
 --		clicker:set_attach(self.object,'',{x=20,y=3,z=0},{x=0,y=0,z=0})
 		clicker:set_attach(self.object,'',{x=-3,y=2,z=-21},{x=0,y=0,z=0})
 		clicker:set_eye_offset({x=0,y=0,z=-20},{x=0,y=0,z=-5})
-		if player_compat then player_compat.player_attached[clicker:get_player_name()] = true end
+		if xcompat.player then xcompat.player.player_attached[clicker:get_player_name()] = true end
 		minetest.after(0.2, function()
 
-			if player_compat and player_compat_animate then player_compat.set_animation(clicker, "sit" , 30) end
+			if xcompat.player then xcompat.player.set_animation(clicker, "sit" , 30) end
 		end)
 		self.driver = clicker:get_player_name()
 	else
 		clicker:set_detach()
-		if player_compat then player_compat.player_attached[clicker:get_player_name()] = false end
+		if xcompat.player then xcompat.player.player_attached[clicker:get_player_name()] = false end
 		clicker:set_eye_offset({x=0,y=0,z=0},{x=0,y=0,z=0})
-		if player_compat and player_compat_animate then player_compat.set_animation(clicker, "stand" , 30) end
+		if xcompat.player then xcompat.player.set_animation(clicker, "stand" , 30) end
 		self.driver = nil
 	end
 end,

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,2 @@
 name = sailing_kit
-depends = mobkit,default
+depends = mobkit,xcompat

--- a/regstuff.lua
+++ b/regstuff.lua
@@ -37,16 +37,16 @@ minetest.register_craftitem("sailing_kit:cloth", {
 minetest.register_craft({
 	output = "sailing_kit:cloth",
 	recipe = {
-		{"farming:string","farming:string","farming:string"},
-		{"farming:string","farming:string","farming:string"},
-		{"farming:string","farming:string","farming:string"},
+		{xcompat.materials.string,xcompat.materials.string,xcompat.materials.string},
+		{xcompat.materials.string,xcompat.materials.string,xcompat.materials.string},
+		{xcompat.materials.string,xcompat.materials.string,xcompat.materials.string},
 	},
 })
 
 minetest.register_craft({
 	output = "sailing_kit:boat",
 	recipe = {
-		{"farming:string","sailing_kit:cloth","farming:string"},
+		{xcompat.materials.string,"sailing_kit:cloth",xcompat.materials.string},
 		{"group:wood", "sailing_kit:cloth","group:wood"},
 		{"group:wood", "group:wood", "group:wood"},
 	},


### PR DESCRIPTION
This makes the mod compatible with games like Mineclonia and VoxeLibre (the latter being untested ftr), while still working exactly the same with the same recipes on Minetest Game, another default games. 

It removes the `default` dependency and adds the `xcompat` (the standard compatability mod) dependency.

Tested on minetest and mineclonia.